### PR TITLE
Fixed broken compile errors.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "const-concat"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Jef <jackefransham@gmail.com>"]
 description = "Heinous hackery to concatenate constants"
 license = "Unlicense"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,20 +1,17 @@
 #![feature(
     const_fn,
     const_fn_union,
-    const_str_as_bytes,
-    const_str_len,
     untagged_unions,
     const_raw_ptr_deref
 )]
 
-#[allow(unions_with_drop_fields)]
 pub const unsafe fn transmute<From, To>(from: From) -> To {
     union Transmute<From, To> {
-        from: From,
-        to: To,
+        from: std::mem::ManuallyDrop<From>,
+        to: std::mem::ManuallyDrop<To>,
     }
 
-    Transmute { from }.to
+    std::mem::ManuallyDrop::into_inner(Transmute { from: std::mem::ManuallyDrop::new(from) }.to)
 }
 
 pub const unsafe fn concat<First, Second, Out>(a: &[u8], b: &[u8]) -> Out


### PR DESCRIPTION
I was receiving a E0740 error code while compiling saying that `unions may not contain fields that need dropping` even though the `[allow(unions_with_drop_fields)]` is there. This is what the compiler recommends and now compiles with rustc version 1.41.0.