### PR TITLE
fix:unions may not contain fields that need dropping

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,20 +1,19 @@
 #![feature(
     const_fn,
     const_fn_union,
-    const_str_as_bytes,
-    const_str_len,
     untagged_unions,
     const_raw_ptr_deref
 )]
 
-#[allow(unions_with_drop_fields)]
+use std::mem::ManuallyDrop;
+
 pub const unsafe fn transmute<From, To>(from: From) -> To {
     union Transmute<From, To> {
-        from: From,
-        to: To,
+        from: ManuallyDrop<From>,
+        to: ManuallyDrop<To>,
     }
 
-    Transmute { from }.to
+    ManuallyDrop::into_inner(Transmute{from:ManuallyDrop::new(from)}.to)
 }
 
 pub const unsafe fn concat<First, Second, Out>(a: &[u8], b: &[u8]) -> Out


### PR DESCRIPTION
Compile error since some version before, at least can't work on "cargo 1.49.0-nightly".
So I add "ManuallyDrop" to make it work.
![image](https://user-images.githubusercontent.com/13222615/99876258-91bbfa00-2c30-11eb-843f-0d029d2f7b4c.png)
